### PR TITLE
[Neg Latency] Decouple display frame rate from update frame rate

### DIFF
--- a/scripts/latency_demo.js
+++ b/scripts/latency_demo.js
@@ -430,12 +430,9 @@ class GameEnvironment {
             if (!this.collided) {
                 this.update();
             }
-            this.render();
+            window.setTimeout(this.loop.bind(this), 1000 / 60);
         }
-
-        if (this.active) {
-            window.requestAnimationFrame(this.loop.bind(this));
-        }
+        window.requestAnimationFrame(this.render.bind(this));
     }
 }
 


### PR DESCRIPTION
Excellent interactive explanation! This is the good content I subscribe to /r/programming for 😃

I saw [this comment](https://www.reddit.com/r/programming/comments/ebg0uv/i_tried_to_implement_google_stadias_negative/fb4vvsp/) on Reddit and I think this is what they were asking for. The idea is just that if our game needs to run at 60 FPS, we need to hardcode that ourselves so a faster refresh rate doesn't double our update speed. It's still not perfect, as the interval between callbacks won't be exactly the same each time, but that's a problem that `requestAnimationFrame` already had.

We still want to gate the rendering part behind behind `requestAnimationFrame`, as we want to allow the browser to deny our request and avoid rendering if our refresh rate is slower than 60FPS or our tab is backgrounded.